### PR TITLE
Implement skeleton for Jarvis-like desktop assistant

### DIFF
--- a/commands.py
+++ b/commands.py
@@ -1,0 +1,72 @@
+import os
+import subprocess
+from datetime import datetime
+import webbrowser
+
+import psutil
+import pyautogui
+
+from config import load_config, save_config
+from memory import Memory
+from voice import speak
+
+
+class CommandHandler:
+    def __init__(self, memory, config, tts_engine=None):
+        self.memory = memory
+        self.config = config
+        self.tts_engine = tts_engine
+
+    def confirm(self, action):
+        if not self.config.get('ask_permission', True):
+            return True
+        speak(f"Do you want me to {action}?", self.tts_engine)
+        # Simplified confirmation via keyboard input
+        resp = input(f"Confirm to {action}? (y/n): ").strip().lower()
+        if resp.startswith('y'):
+            return True
+        return False
+
+    def handle(self, text):
+        response = ""
+        if not text:
+            response = "Sorry, I didn't understand that."
+            speak(response, self.tts_engine)
+            return response
+
+        lower = text.lower()
+        if 'time' in lower:
+            now = datetime.now().strftime('%H:%M')
+            response = f"It is {now}."
+        elif 'weather' in lower:
+            # Placeholder for weather logic
+            response = "I cannot fetch weather right now."
+        elif 'open notepad' in lower:
+            if self.confirm('open Notepad'):
+                subprocess.Popen('notepad')
+                response = 'Opening Notepad.'
+            else:
+                response = 'Action cancelled.'
+        elif 'open calculator' in lower:
+            if self.confirm('open Calculator'):
+                subprocess.Popen('calc')
+                response = 'Opening Calculator.'
+            else:
+                response = 'Action cancelled.'
+        elif 'open chrome' in lower or 'open browser' in lower:
+            if self.confirm('open the browser'):
+                webbrowser.open('https://www.google.com')
+                response = 'Opening browser.'
+            else:
+                response = 'Action cancelled.'
+        elif 'do what you want' in lower or 'no need to ask' in lower:
+            self.config['ask_permission'] = False
+            save_config(self.config)
+            response = 'Okay, I will no longer ask for permission.'
+        else:
+            response = "This action is not supported."
+
+        speak(response, self.tts_engine)
+        self.memory.log(text, response)
+        return response
+

--- a/config.py
+++ b/config.py
@@ -1,0 +1,19 @@
+import json
+from pathlib import Path
+
+CONFIG_PATH = Path('config.json')
+
+def load_config():
+    if CONFIG_PATH.exists():
+        with open(CONFIG_PATH, 'r', encoding='utf-8') as f:
+            return json.load(f)
+    return {
+        'user_name': 'Invar',
+        'ask_permission': True,
+        'language': 'auto'
+    }
+
+def save_config(config):
+    with open(CONFIG_PATH, 'w', encoding='utf-8') as f:
+        json.dump(config, f, ensure_ascii=False, indent=2)
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,31 @@
+from config import load_config, save_config
+from memory import Memory
+from voice import init_tts, speak, Listener
+from commands import CommandHandler
+
+
+def greet(engine, config):
+    name = config.get('user_name', 'User')
+    speak(f"Hello {name}, how can I help you?", engine)
+
+
+def main():
+    config = load_config()
+    memory = Memory()
+    engine = init_tts()
+    listener = Listener(language=config.get('language', 'auto'))
+    handler = CommandHandler(memory, config, tts_engine=engine)
+
+    greet(engine, config)
+
+    while True:
+        text = listener.listen()
+        response = handler.handle(text)
+        if response == 'quit':
+            break
+        save_config(config)
+
+
+if __name__ == '__main__':
+    main()
+

--- a/memory.py
+++ b/memory.py
@@ -1,0 +1,23 @@
+import json
+from pathlib import Path
+from datetime import datetime
+
+HISTORY_PATH = Path('history.json')
+
+class Memory:
+    def __init__(self):
+        self.history = []
+        if HISTORY_PATH.exists():
+            with open(HISTORY_PATH, 'r', encoding='utf-8') as f:
+                self.history = json.load(f)
+
+    def log(self, user_input, response):
+        entry = {
+            'timestamp': datetime.utcnow().isoformat(),
+            'input': user_input,
+            'response': response
+        }
+        self.history.append(entry)
+        with open(HISTORY_PATH, 'w', encoding='utf-8') as f:
+            json.dump(self.history, f, ensure_ascii=False, indent=2)
+

--- a/voice.py
+++ b/voice.py
@@ -1,0 +1,43 @@
+import pyttsx3
+import speech_recognition as sr
+
+
+def init_tts():
+    engine = pyttsx3.init()
+    # Set Jarvis-like voice if available
+    for voice in engine.getProperty('voices'):
+        if 'David' in voice.name:
+            engine.setProperty('voice', voice.id)
+            break
+    engine.setProperty('rate', 150)
+    return engine
+
+
+def speak(text, engine=None):
+    if engine is None:
+        engine = init_tts()
+    print(text)
+    engine.say(text)
+    engine.runAndWait()
+
+
+class Listener:
+    def __init__(self, language='auto'):
+        self.recognizer = sr.Recognizer()
+        self.microphone = sr.Microphone()
+        self.language = language
+
+    def listen(self):
+        with self.microphone as source:
+            self.recognizer.adjust_for_ambient_noise(source)
+            audio = self.recognizer.listen(source)
+        try:
+            if self.language == 'auto':
+                return self.recognizer.recognize_google(audio)
+            else:
+                return self.recognizer.recognize_google(audio, language=self.language)
+        except sr.UnknownValueError:
+            return None
+        except sr.RequestError:
+            return None
+


### PR DESCRIPTION
## Summary
- add configuration loader/saver for user settings
- add memory module storing conversation history
- implement voice input/output using speech_recognition and pyttsx3
- create command handler for basic actions and permissions
- main loop to keep listening and responding

## Testing
- `python3 -m py_compile *.py`

------
https://chatgpt.com/codex/tasks/task_e_684fc893411c8333aa9a603acbce9592